### PR TITLE
Dropping dependency on birth_datetime in favor of *_of_birth fields

### DIFF
--- a/spark_apps/generate_training_data.py
+++ b/spark_apps/generate_training_data.py
@@ -23,9 +23,7 @@ def main(input_folder, output_folder, domain_table_list, date_filter,
     visit_occurrence = visit_occurrence.select('visit_occurrence_id', 'visit_concept_id',
                                                'person_id')
     person = preprocess_domain_table(spark, input_folder, PERSON)
-    person = person.select('person_id', F.coalesce('birth_datetime',
-                                                   F.concat('year_of_birth', F.lit('-01-01')).cast(
-                                                       'timestamp')).alias('birth_datetime'))
+    person = person.select('person_id', F.concat('year_of_birth', F.lit('-'), F.coalesce('month_of_birth', F.lit('01')), F.lit('-'), F.coalesce('day_of_birth', F.lit('01'))).cast('timestamp').alias('birth_datetime'))
     visit_occurrence_person = visit_occurrence.join(person, 'person_id')
 
     patient_event = join_domain_tables(domain_tables)


### PR DESCRIPTION
I don't know of any database that has the `person.birth_datetime` field populated (it is not required). This code change instead relies on the `year_of_birth`, `month_of_birth`, and `day_of_birth` fields. This change should make the code more compatible with more databases.