### PR TITLE
fixed the data conversion when using dask dataframes

### DIFF
--- a/data_generators/tokenizer.py
+++ b/data_generators/tokenizer.py
@@ -17,11 +17,11 @@ class ConceptTokenizer:
     def fit_on_concept_sequences(self, concept_sequences: Union[df_series, dd_series]):
 
         if isinstance(concept_sequences, df_series):
-            self.tokenizer.fit_on_texts(concept_sequences.apply(
-                lambda concept_ids: concept_ids.tolist()))
+            self.tokenizer.fit_on_texts(map(list, concept_sequences))
         else:
             self.tokenizer.fit_on_texts(
-                concept_sequences.apply(lambda s: s.tolist(), meta='iterable'))
+                concept_sequences.apply(list, meta='iterable')
+            )
 
         self.tokenizer.fit_on_texts(self.mask_token)
         self.tokenizer.fit_on_texts(self.unused_token)

--- a/trainers/train_bert_only.py
+++ b/trainers/train_bert_only.py
@@ -59,7 +59,8 @@ class VanillaBertTrainer(AbstractConceptEmbeddingTrainer):
             f'include_prolonged_length_stay: {include_prolonged_length_stay}\n'
             f'use_time_embeddings: {use_time_embedding}\n'
             f'use_behrt: {use_behrt}\n'
-            f'time_embeddings_size: {time_embeddings_size}')
+            f'time_embeddings_size: {time_embeddings_size}'
+        )
 
     def _load_dependencies(self):
 

--- a/utils/model_utils.py
+++ b/utils/model_utils.py
@@ -79,12 +79,14 @@ def tokenize_concepts(training_data: Union[pd_dataframe, dd_dataframe],
     if isinstance(training_data, dd_dataframe):
         training_data[tokenized_column_name] = training_data[column_name].map_partitions(
             lambda ds: pd.Series(
-                tokenizer.encode(map(lambda t: t[1].tolist(), ds.iteritems()), is_generator=True),
-                name='concept_ids'), meta='iterable')
+                tokenizer.encode(map(lambda t: list(t[1]), ds.iteritems()), is_generator=True),
+                name='concept_ids'),
+            meta='iterable'
+        )
     else:
-        training_data[column_name] = training_data[column_name].apply(
-            lambda concept_ids: concept_ids.tolist())
-        training_data[tokenized_column_name] = tokenizer.encode(training_data[column_name])
+        training_data[tokenized_column_name] = tokenizer.encode(
+            map(list, training_data[column_name])
+        )
 
     if not os.path.exists(tokenizer_path) or recreate:
         pickle.dump(tokenizer, open(tokenizer_path, 'wb'))


### PR DESCRIPTION
When using dask dataframes, the patient history column `concept_ids` could be NumPy arrays and therefore we need to convert it into a `list` so we can call the tokenizer on it