### PR TITLE
Link events to same day visits (option 2) and add parameter to creating visits (option 3)

### DIFF
--- a/spark_apps/generate_training_data.py
+++ b/spark_apps/generate_training_data.py
@@ -2,7 +2,6 @@ import os
 import argparse
 import datetime
 
-import fsspec.implementations.webhdfs
 from pyspark.sql import SparkSession
 
 from utils.spark_utils import *

--- a/spark_apps/generate_training_data.py
+++ b/spark_apps/generate_training_data.py
@@ -16,7 +16,7 @@ def main(input_folder, output_folder, domain_table_list, date_filter,
          include_visit_type, is_new_patient_representation, exclude_visit_tokens,
          is_classic_bert, include_prolonged_stay, create_visits_from_dates, create_visit_gap,
          link_events_visits):
-    spark = SparkSession.builder.appName('Generate Bert Training Data').config('spark.driver.memory', '15g').getOrCreate()
+    spark = SparkSession.builder.appName('Generate Bert Training Data').getOrCreate()
     domain_tables = []
     for domain_table_name in domain_table_list:
         domain_tables.append(preprocess_domain_table(spark, input_folder, domain_table_name))
@@ -41,6 +41,9 @@ def main(input_folder, output_folder, domain_table_list, date_filter,
 
     if create_visits_from_dates:
         patient_event = create_visits(patient_event, link_events_visits, create_visit_gap)
+
+    patient_event = patient_event.filter(F.col("visit_occurrence_id").isNotNull())
+
 
     if is_new_patient_representation:
         sequence_data = create_sequence_data_with_att(patient_event,
@@ -132,6 +135,7 @@ if __name__ == '__main__':
                         dest='create_visit_gap',
                         action='store',
                         type=int,
+                        default=1,
                         help='Specify gap when creating visits artificially')
     parser.add_argument('--link_events_to_visits',
                         dest='link_events_visits',

--- a/spark_apps/generate_training_data.py
+++ b/spark_apps/generate_training_data.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import datetime
 
+import fsspec.implementations.webhdfs
 from pyspark.sql import SparkSession
 
 from utils.spark_utils import *
@@ -13,8 +14,9 @@ PERSON = 'person'
 
 def main(input_folder, output_folder, domain_table_list, date_filter,
          include_visit_type, is_new_patient_representation, exclude_visit_tokens,
-         is_classic_bert, include_prolonged_stay, create_visits_from_dates):
-    spark = SparkSession.builder.appName('Generate Bert Training Data').getOrCreate()
+         is_classic_bert, include_prolonged_stay, create_visits_from_dates, create_visit_gap,
+         link_events_visits):
+    spark = SparkSession.builder.appName('Generate Bert Training Data').config('spark.driver.memory', '15g').getOrCreate()
     domain_tables = []
     for domain_table_name in domain_table_list:
         domain_tables.append(preprocess_domain_table(spark, input_folder, domain_table_name))
@@ -24,32 +26,27 @@ def main(input_folder, output_folder, domain_table_list, date_filter,
                                                'person_id')
     person = preprocess_domain_table(spark, input_folder, PERSON)
     person = person.select('person_id', F.concat('year_of_birth', F.lit('-'), F.coalesce('month_of_birth', F.lit('01')), F.lit('-'), F.coalesce('day_of_birth', F.lit('01'))).cast('timestamp').alias('birth_datetime'))
-    visit_occurrence_person = visit_occurrence.join(person, 'person_id')
 
     patient_event = join_domain_tables(domain_tables)
-    if create_visits_from_dates:
-        patient_event = patient_event.join(person, 'person_id') \
-            .select([patient_event[fieldName] for fieldName in patient_event.schema.fieldNames()] +
-                    ['birth_datetime']) \
-            .withColumn('cohort_member_id', F.col('person_id')) \
-            .withColumn('age', F.ceil(F.months_between(F.col('date'),
-                                                       F.col("birth_datetime")) / F.lit(12)))
-    else:
-        visit_occurrence_person = visit_occurrence.join(person, 'person_id')
 
-        patient_event = patient_event.join(visit_occurrence_person, 'visit_occurrence_id') \
-            .select([patient_event[fieldName] for fieldName in patient_event.schema.fieldNames()] +
-                    ['visit_concept_id', 'birth_datetime']) \
-            .withColumn('cohort_member_id', F.col('person_id')) \
-            .withColumn('age', F.ceil(F.months_between(F.col('date'),
-                                                       F.col("birth_datetime")) / F.lit(12)))
+    patient_event = patient_event.join(visit_occurrence, on=['visit_occurrence_id'], how='left') \
+        .join(person, on="person_id") \
+        .select([patient_event[fieldName] for fieldName in patient_event.schema.fieldNames()] +
+                ['visit_concept_id', 'birth_datetime']) \
+        .withColumn('cohort_member_id', F.col('person_id')) \
+        .withColumn('age', F.ceil(F.months_between(F.col('date'),
+                                                   F.col("birth_datetime")) / F.lit(12)))
+    if link_events_visits:
+        patient_event = link_events_with_visits(patient_event)
+
+    if create_visits_from_dates:
+        patient_event = create_visits(patient_event, link_events_visits, create_visit_gap)
 
     if is_new_patient_representation:
         sequence_data = create_sequence_data_with_att(patient_event,
                                                       date_filter=date_filter,
                                                       include_visit_type=include_visit_type,
-                                                      exclude_visit_tokens=exclude_visit_tokens,
-                                                      create_visits_from_dates=create_visits_from_dates)
+                                                      exclude_visit_tokens=exclude_visit_tokens)
     else:
         sequence_data = create_sequence_data(patient_event,
                                              date_filter=date_filter,
@@ -131,8 +128,19 @@ if __name__ == '__main__':
                         action='store_true',
                         help='Specify whether to create visits so events falling on consecutive '
                              'days belong to same visit')
+    parser.add_argument('--create_visit_gap',
+                        dest='create_visit_gap',
+                        action='store',
+                        type=int,
+                        help='Specify gap when creating visits artificially')
+    parser.add_argument('--link_events_to_visits',
+                        dest='link_events_visits',
+                        action='store_true',
+                        help='Try to link events without visit info to same day visits')
+
     ARGS = parser.parse_args()
 
     main(ARGS.input_folder, ARGS.output_folder, ARGS.domain_table_list, ARGS.date_filter,
          ARGS.include_visit_type, ARGS.is_new_patient_representation, ARGS.exclude_visit_tokens,
-         ARGS.is_classic_bert_sequence, ARGS.include_prolonged_stay, ARGS.create_visits_from_dates)
+         ARGS.is_classic_bert_sequence, ARGS.include_prolonged_stay, ARGS.create_visits_from_dates,
+         ARGS.create_visit_gap, ARGS.link_events_visits)

--- a/utils/spark_utils.py
+++ b/utils/spark_utils.py
@@ -781,9 +781,7 @@ def create_visits(patient_event, link_events_visits, gap):
         patient_event = patient_event.withColumn("_max", F.max(F.col("visit_occurrence_id")).over(whole_window))
 
         patient_event = patient_event.withColumn("visit_occurrence_id",
-                                                 F.when(patient_event.visit_occurrence_id.isNull(),
-                                                        F.col("_max") + F.sum("_flg").over(window)) \
-                                                 .otherwise(patient_event.visit_occurrence_id))
+                                                 F. coalesce(F.col("visit_occurrence_id"), F.col("_max") + F.sum("_flg").over(window))
         patient_event = patient_event.drop("_max")
         # add visit_concept_id=0 for the artificially constructed visits
         patient_event = patient_event.withColumn('visit_concept_id', F. coalesce('visit_concept_id', F.lit(0)))

--- a/utils/spark_utils.py
+++ b/utils/spark_utils.py
@@ -786,9 +786,7 @@ def create_visits(patient_event, link_events_visits, gap):
                                                  .otherwise(patient_event.visit_occurrence_id))
         patient_event = patient_event.drop("_max")
         # add visit_concept_id=0 for the artificially constructed visits
-        patient_event = patient_event.withColumn('visit_concept_id',
-                                                 F.when(patient_event.visit_concept_id.isNull(), F.lit(0)) \
-                                                 .otherwise(F.col("visit_concept_id")))
+        patient_event = patient_event.withColumn('visit_concept_id', F. coalesce('visit_concept_id', F.lit(0)))
     else:
         # create visit_occurrence_ids
         patient_event = patient_event.withColumn("_flg", F.coalesce(F.when(F.col("date_difference") > gap, 1),

--- a/utils/spark_utils.py
+++ b/utils/spark_utils.py
@@ -446,25 +446,6 @@ def create_sequence_data_with_att(patient_event, date_filter=None,
     if date_filter:
         patient_event = patient_event.where(F.col('date').cast('date') >= date_filter)
 
-    if create_visits_from_dates:
-        # create date_diff column
-        window = W.partitionBy("cohort_member_id", "person_id").orderBy("date")
-        patient_event = patient_event.withColumn("date_difference",
-                                                 F.datediff(patient_event.date,
-                                                            F.lag(patient_event.date, 1).over(
-                                                                window)))
-        # first row per person_id gives nan for date_difference, replace with value 2
-        patient_event = patient_event.na.fill(2, "date_difference")
-
-        # create visit_occurrence_ids
-        patient_event = patient_event.withColumn("_flg", F.coalesce(F.when(F.col("date_difference") > 1, 1),
-                                                                    F.lit(0)))
-        patient_event = patient_event.withColumn("visit_occurrence_id", F.sum("_flg").over(window))
-
-        # add visit_concept_id=0 for the artificially constructed visits
-        patient_event = patient_event .withColumn('visit_concept_id', F.lit(0))
-        
-        patient_event = patient_event .drop("date_difference", "_flg")
     # Udf for identifying the earliest date associated with a visit_occurrence_id
     visit_start_date_udf = F.first('date').over(
         W.partitionBy('cohort_member_id', 'person_id', 'visit_occurrence_id').orderBy('date'))
@@ -759,3 +740,64 @@ def get_standard_concept_ids(spark, concept_ids):
             WHERE ca.concept_id_1 IN ({concept_ids})
         """.format(concept_ids=','.join([str(c) for c in concept_ids])))
     return standard_concept_ids
+
+
+def link_events_with_visits(patient_event):
+    """
+    Links events without a visit_occurrence_id to a same day visit
+    """
+    window = W.partitionBy(['cohort_member_id', 'person_id', 'date'])
+    patient_event = patient_event.withColumn('visit_occurrence_id',
+                                             F.last('visit_occurrence_id', ignorenulls=True).over(window)) \
+        .withColumn('visit_concept_id', F.last('visit_concept_id', ignorenulls=True).over(window))
+    return patient_event
+
+
+def create_visits(patient_event, link_events_visits, gap):
+    """
+    Creates visits as a consecutive sequence of events.
+    The parameter gap controls what events are considered consecutive. A gap of 1
+    means events with 0 days between them are consecutive. A gap of 0 means only same day events
+    are consecutive.
+    """
+    # create date_diff column
+    window = W.partitionBy("cohort_member_id", "person_id").orderBy("date")
+    patient_event = patient_event.withColumn("date_difference",
+                                             F.datediff(patient_event.date,
+                                                        F.lag(patient_event.date, 1).over(
+                                                            window)))
+    # first row per person_id gives nan for date_difference, replace with value 2
+    patient_event = patient_event.na.fill(2, "date_difference")
+
+    if link_events_visits:
+        # only create visits when visit info is missing
+        patient_event = patient_event.withColumn("_flg",
+                                                 F.coalesce(F.when((F.col("date_difference") > gap) & \
+                                                                   (F.col("visit_occurrence_id").isNull()), 1),
+                                                            F.lit(0)))
+
+        # make sure new visit ids are not clashing with existing
+        whole_window = W.partitionBy("cohort_member_id", "person_id")
+        patient_event = patient_event.withColumn("_max", F.max(F.col("visit_occurrence_id")).over(whole_window))
+
+        patient_event = patient_event.withColumn("visit_occurrence_id",
+                                                 F.when(patient_event.visit_occurrence_id.isNull(),
+                                                        F.col("_max") + F.sum("_flg").over(window)) \
+                                                 .otherwise(patient_event.visit_occurrence_id))
+        patient_event = patient_event.drop("_max")
+        # add visit_concept_id=0 for the artificially constructed visits
+        patient_event = patient_event.withColumn('visit_concept_id',
+                                                 F.when(patient_event.visit_concept_id.isNull(), F.lit(0)) \
+                                                 .otherwise(F.col("visit_concept_id")))
+    else:
+        # create visit_occurrence_ids
+        patient_event = patient_event.withColumn("_flg", F.coalesce(F.when(F.col("date_difference") > gap, 1),
+                                                                    F.lit(0)))
+        patient_event = patient_event.withColumn("visit_occurrence_id", F.sum("_flg").over(window))
+
+        # add visit_concept_id=0 for the artificially constructed visits
+        patient_event = patient_event.withColumn('visit_concept_id', F.lit(0))
+
+    patient_event = patient_event.drop("date_difference", "_flg")
+
+    return patient_event


### PR DESCRIPTION
In this PR I've added

- Link same day events without a ```visit_occurrence_id``` to same day visit if possible (fixes #22)
- Added the option to both try to link events to visits, and then create visits from the leftover orphan events (if any)
- Added a gap parameter to specify how far away events need to be before they are considered the same visit
- Moved the create visit functionality to an earlier stage in the pipeline and refactored into a function

@schuemie @ChaoPang 