### PR TITLE
specified pyarrow as the engine when using dask dataframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ If you don't have your own OMOP instance, we have provided a sample of patient s
 ```console
 PYTHONPATH=./: python3 trainers/train_bert_only.py -i sample_data/ -o ~/Documents/omop_test/cehr-bert -iv -m 512 -e 2 -b 32 -d 5 --use_time_embedding 
 ```
+If your dataset is large, you could add ```--use_dask``` in the command above 
 ### 4. Generate hf readmission prediction task
 If you don't have your own OMOP instance, we have provided a sample of patient sequence data generated using Synthea at `sample/hf_readmissioon` in the repo
 ```console

--- a/trainers/model_trainer.py
+++ b/trainers/model_trainer.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 import os
+import glob
 from pathlib import Path
 import pandas as pd
 import dask.dataframe as dd
@@ -103,7 +104,12 @@ class AbstractConceptEmbeddingTrainer(AbstractModel):
             raise FileExistsError(f'{self._training_data_parquet_path} does not exist!')
 
         if self._use_dask:
-            return dd.read_parquet(self._training_data_parquet_path, engine='pyarrow')
+            # if the path is a directory
+            if os.path.isdir(self._training_data_parquet_path):
+                parquet_files = glob.glob(os.path.join(self._training_data_parquet_path, '*.parquet'))
+                return dd.read_parquet(parquet_files, engine='pyarrow')
+            else:
+                return dd.read_parquet(self._training_data_parquet_path, engine='pyarrow')
         else:
             return pd.read_parquet(self._training_data_parquet_path)
 

--- a/trainers/model_trainer.py
+++ b/trainers/model_trainer.py
@@ -121,7 +121,9 @@ class AbstractConceptEmbeddingTrainer(AbstractModel):
         :return:
         """
         data_generator = self.create_data_generator()
+        self.get_logger().info('Calculating steps per epoch')
         steps_per_epoch = data_generator.get_steps_per_epoch()
+        self.get_logger().info(f'Calculated {steps_per_epoch} steps per epoch')
         dataset = tf.data.Dataset.from_generator(data_generator.create_batch_generator,
                                                  output_types=(
                                                      data_generator.get_tf_dataset_schema()))

--- a/trainers/model_trainer.py
+++ b/trainers/model_trainer.py
@@ -104,12 +104,7 @@ class AbstractConceptEmbeddingTrainer(AbstractModel):
             raise FileExistsError(f'{self._training_data_parquet_path} does not exist!')
 
         if self._use_dask:
-            # if the path is a directory
-            if os.path.isdir(self._training_data_parquet_path):
-                parquet_files = glob.glob(os.path.join(self._training_data_parquet_path, '*.parquet'))
-                return dd.read_parquet(parquet_files, engine='pyarrow')
-            else:
-                return dd.read_parquet(self._training_data_parquet_path, engine='pyarrow')
+            return dd.read_parquet(self._training_data_parquet_path, engine='pyarrow')
         else:
             return pd.read_parquet(self._training_data_parquet_path)
 

--- a/trainers/model_trainer.py
+++ b/trainers/model_trainer.py
@@ -103,7 +103,7 @@ class AbstractConceptEmbeddingTrainer(AbstractModel):
             raise FileExistsError(f'{self._training_data_parquet_path} does not exist!')
 
         if self._use_dask:
-            return dd.read_parquet(self._training_data_parquet_path)
+            return dd.read_parquet(self._training_data_parquet_path, engine='pyarrow')
         else:
             return pd.read_parquet(self._training_data_parquet_path)
 

--- a/trainers/train_bert_only.py
+++ b/trainers/train_bert_only.py
@@ -64,10 +64,12 @@ class VanillaBertTrainer(AbstractConceptEmbeddingTrainer):
 
     def _load_dependencies(self):
 
-        self._tokenizer = tokenize_concepts(self._training_data,
-                                            'concept_ids',
-                                            'token_ids',
-                                            self._tokenizer_path)
+        self._tokenizer = tokenize_concepts(
+            self._training_data,
+            'concept_ids',
+            'token_ids',
+            self._tokenizer_path
+        )
 
         if self._include_visit_prediction:
             self._visit_tokenizer = tokenize_concepts(self._training_data,


### PR DESCRIPTION
When `--use_dask` is provided in running the model trainer, the dask dataframe is used instead of the pandas dataframe to handle the big dataset. However, the tokenization didn't work for the dask dataframe previously with the `engine=pyarrow`. A temp workaround has been put in to tokenize `concept_ids` properly, we will move the tokenization logic to the data generator in the future. 