### PR TITLE
Normalize visit_concept_orders before padding

### DIFF
--- a/data_generators/learning_objective.py
+++ b/data_generators/learning_objective.py
@@ -285,8 +285,8 @@ class MaskedLanguageModelLearningObjective(LearningObjective):
         time_stamps = post_pad_pre_truncate(time_stamps, 0, self._max_seq_len)
         ages = post_pad_pre_truncate(ages, 0, self._max_seq_len)
         visit_concept_orders = post_pad_pre_truncate(visit_concept_orders,
-                                                     self._max_seq_len,
-                                                     self._max_seq_len)
+                                                     pad_value=self._max_seq_len-1,
+                                                     max_seq_len=self._max_seq_len)
 
         input_dict = {'masked_concept_ids': masked_concepts,
                       'concept_ids': concepts,
@@ -322,6 +322,9 @@ class MaskedLanguageModelLearningObjective(LearningObjective):
             *list(islice(sorted_list, left_index, right_index)))
 
         masked_concepts, output_mask = self._mask_concepts(concepts)
+
+        # Normalize the visit_orders using the smallest visit_concept_orders
+        visit_concept_orders = visit_concept_orders - min(visit_concept_orders)
 
         return output_mask, masked_concepts, concepts, dates, segments, ages, visit_concept_orders
 

--- a/models/custom_layers.py
+++ b/models/custom_layers.py
@@ -321,11 +321,6 @@ class PositionalEncodingLayer(tf.keras.layers.Layer):
         return config
 
     def call(self, visit_concept_orders):
-        # Normalize the visit_orders using the smallest visit_concept_orders
-        # Take the absolute value to make sure the padded values are not negative after
-        # normalization
-        visit_concept_orders = tf.abs(visit_concept_orders - tf.expand_dims(
-            tf.math.reduce_min(visit_concept_orders, axis=1), axis=-1))
         # Get the same positional encodings for the concepts with the same visit_order
         positional_embeddings = tf.gather(self.pos_encoding, visit_concept_orders, axis=0)
         return positional_embeddings


### PR DESCRIPTION
Fixes errors like ` indices[13,0] = 3326 is not in [0, 512)`